### PR TITLE
Nuget symbols

### DIFF
--- a/GH_UnitNumber/GH_UnitNumberAssemblyInfo.cs
+++ b/GH_UnitNumber/GH_UnitNumberAssemblyInfo.cs
@@ -36,7 +36,7 @@ namespace GH_UnitNumber
     internal const string Company = "Oasys";
     internal const string Copyright = "Copyright © Oasys 1985 - 2022";
     internal const string Contact = "https://www.oasys-software.com/";
-    internal const string Vers = "0.3.11";
+    internal const string Vers = "0.3.12";
     internal static bool isBeta = true;
     internal const string ProductName = "UnitNumber";
     internal const string PluginName = "UnitNumber";

--- a/OasysGH/OasysGH.csproj
+++ b/OasysGH/OasysGH.csproj
@@ -4,7 +4,7 @@
   <!-- NuGet properties -->
   <PropertyGroup>
     <PackageId>OasysGH</PackageId>
-    <Version>0.3.11-beta</Version>
+    <Version>0.3.12-beta</Version>
     <Authors>Oasys</Authors>
     <Title>OasysGH</Title>
     <Description>OasysGH is a library with shared content for Oasys Grasshopper plugins.</Description>
@@ -15,7 +15,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>oasys grasshopper</PackageTags>
-    <PackageReleaseNotes>This is a release of OasysGH 0.3.11-beta.</PackageReleaseNotes>
+    <PackageReleaseNotes>This is a release of OasysGH 0.3.12-beta.</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/OasysGH/OasysPluginInfo.cs
+++ b/OasysGH/OasysPluginInfo.cs
@@ -22,7 +22,7 @@ namespace OasysGH
 
   internal sealed class PluginInfo
   {
-    internal const string Version = "0.3.11";
+    internal const string Version = "0.3.12";
 
     private static readonly Lazy<OasysPluginInfo> lazy =
         new Lazy<OasysPluginInfo>(() => new OasysPluginInfo(

--- a/build-test-deploy.yml
+++ b/build-test-deploy.yml
@@ -116,7 +116,7 @@ steps:
 
 - powershell: |
     cd OasysGH
-    & 'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\amd64\MSBuild.exe' OasysGH.csproj /t:pack /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg /p:DebugType=portable
+    & 'C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\amd64\MSBuild.exe' OasysGH.csproj /t:pack /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg /p:DebugType=portable /property:Configuration=Debug
   condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'), ne(variables.TAG_EXISTS, 'true'))
   displayName: Package NuGet
 


### PR DESCRIPTION
Looks like the step to package the nuget + symbols needs

`/property:Configuration=Debug`

set, which feels a bit weird, since we want to 'release', but it works..

see also: https://stackoverflow.com/questions/72133376/embedding-debugging-symbols-in-nuget-does-not-work