### PR TITLE
OGH-45: Resolve the dependency vulnerabilities

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,8 +4,4 @@
     <PlatformTarget>x64</PlatformTarget>
     <Platforms>x64</Platforms>
   </PropertyGroup>
-
-  <ItemGroup Condition="'$(MSBuildProjectName)' == 'OasysGH' or '$(MSBuildProjectName)' == 'OasysGHTests' or '$(MSBuildProjectName)' == 'GH_UnitNumberTests' or '$(MSBuildProjectName)' == 'IntegrationTests'">
-    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.4" />
-  </ItemGroup>
 </Project>

--- a/GH_UnitNumberTests/GH_UnitNumberTests.csproj
+++ b/GH_UnitNumberTests/GH_UnitNumberTests.csproj
@@ -6,7 +6,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Grasshopper" Version="7.38.24338.17001" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="10.0.10" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.5" />
     <PackageReference Include="RhinoWindows" Version="7.38.24338.17001" />
     <PackageReference Include="xunit" Version="2.6.6" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">

--- a/GH_UnitNumberTests/GH_UnitNumberTests.csproj
+++ b/GH_UnitNumberTests/GH_UnitNumberTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Grasshopper" Version="7.38.24338.17001" />
-    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.10" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.5" />
     <PackageReference Include="RhinoWindows" Version="7.38.24338.17001" />
     <PackageReference Include="xunit" Version="2.6.6" />

--- a/IntegrationTests/IntegrationTests.csproj
+++ b/IntegrationTests/IntegrationTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Grasshopper" Version="7.38.24338.17001" />
-    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.10" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.5" />
     <PackageReference Include="RhinoWindows" Version="7.38.24338.17001" />
     <PackageReference Include="xunit" Version="2.6.6" />

--- a/IntegrationTests/IntegrationTests.csproj
+++ b/IntegrationTests/IntegrationTests.csproj
@@ -6,7 +6,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Grasshopper" Version="7.38.24338.17001" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="10.0.10" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.5" />
     <PackageReference Include="RhinoWindows" Version="7.38.24338.17001" />
     <PackageReference Include="xunit" Version="2.6.6" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
@@ -29,7 +30,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
   <Import Project="PreBuild.targets" />
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">

--- a/OasysGH/Helpers/SqlReader.cs
+++ b/OasysGH/Helpers/SqlReader.cs
@@ -25,14 +25,13 @@ namespace OasysGH.Helpers {
     }
 
     public static SqlReader Initialize() {
-      string codeBase = Assembly.GetCallingAssembly().CodeBase;
-      var uri = new UriBuilder(codeBase);
-      string codeBasePath = Path.GetDirectoryName(Uri.UnescapeDataString(uri.Path));
+      string codeBasePath = Path.GetDirectoryName(typeof(SqlReader).Assembly.Location);
+      if (string.IsNullOrEmpty(codeBasePath)) {
+        codeBasePath = AppDomain.CurrentDomain.BaseDirectory;
+      }
 
       try {
-        var SQLiteInterop = Assembly.LoadFile(codeBasePath + @"\Microsoft.Data.Sqlite.dll");
-
-        // Try to create a simple connection to test if SQLite is available
+        Assembly.LoadFile(Path.Combine(codeBasePath, "Microsoft.Data.Sqlite.dll"));
         using (var testConnection = new SqliteConnection("Data Source=:memory:")) {
           testConnection.Open();
           testConnection.Close();
@@ -42,13 +41,8 @@ namespace OasysGH.Helpers {
       }
       // try using a second AppDomain
       catch (Exception) {
-        // Get the full name of the EXE assembly.
-        string exeAssembly = Assembly.GetCallingAssembly().FullName;
-
+        string exeAssembly = typeof(SqlReader).Assembly.FullName;
         AppDomain appDomain = CreateSecondAppDomain(codeBasePath);
-
-        // Create an instance of MarshalbyRefType in the second AppDomain.
-        // A proxy to the object is returned.
         var reader = (SqlReader)appDomain.CreateInstanceAndUnwrap(exeAssembly, typeof(SqlReader).FullName);
         return reader;
       }
@@ -278,8 +272,7 @@ namespace OasysGH.Helpers {
     internal static AppDomain CreateSecondAppDomain(string codeBasePath) {
       // Construct and initialize settings for a second AppDomain.
       var ads = new AppDomainSetup {
-        ApplicationBase = Path.GetDirectoryName(codeBasePath),
-        PrivateBinPath = @"x64",
+        ApplicationBase = codeBasePath,
         DisallowBindingRedirects = false,
         DisallowCodeDownload = true,
         ConfigurationFile = AppDomain.CurrentDomain.SetupInformation.ConfigurationFile

--- a/OasysGH/Helpers/SqlReader.cs
+++ b/OasysGH/Helpers/SqlReader.cs
@@ -16,6 +16,10 @@ namespace OasysGH.Helpers {
     public static SqlReader Instance => lazy.Value;
     private static readonly Lazy<SqlReader> lazy = new Lazy<SqlReader>(() => Initialize());
 
+    static SqlReader() {
+      AppDomain.CurrentDomain.AssemblyResolve += ResolveSQLitePCLRaw;
+    }
+
     public SqlReader() {
       try {
         SQLitePCL.Batteries.Init();
@@ -24,28 +28,44 @@ namespace OasysGH.Helpers {
       }
     }
 
+    // Handles any assembly version mismatch: loads whatever version is present on disk.
+    private static Assembly ResolveSQLitePCLRaw(object sender, ResolveEventArgs args) {
+      string dir = Path.GetDirectoryName(typeof(SqlReader).Assembly.Location)
+                   ?? AppDomain.CurrentDomain.BaseDirectory;
+      string path = Path.Combine(dir, new AssemblyName(args.Name).Name + ".dll");
+      return File.Exists(path) ? Assembly.LoadFrom(path) : null;
+    }
+
     public static SqlReader Initialize() {
       string codeBasePath = Path.GetDirectoryName(typeof(SqlReader).Assembly.Location);
       if (string.IsNullOrEmpty(codeBasePath)) {
         codeBasePath = AppDomain.CurrentDomain.BaseDirectory;
       }
 
-      try {
-        Assembly.LoadFile(Path.Combine(codeBasePath, "Microsoft.Data.Sqlite.dll"));
-        using (var testConnection = new SqliteConnection("Data Source=:memory:")) {
-          testConnection.Open();
-          testConnection.Close();
-        }
+      // In a Rhino/Grasshopper process other plugins may have registered AssemblyResolve
+      // handlers that fire before ours and return a conflicting SQLitePCLRaw.core version.
+      // Skip the shared-domain path entirely and use the isolated AppDomain instead.
+      bool inPluginHost = AppDomain.CurrentDomain.GetAssemblies()
+        .Any(a => a.GetName().Name == "Grasshopper" || a.GetName().Name == "RhinoCommon");
 
-        return new SqlReader();
+      if (!inPluginHost) {
+        try {
+          Assembly.LoadFile(Path.Combine(codeBasePath, "Microsoft.Data.Sqlite.dll"));
+          using (var testConnection = new SqliteConnection("Data Source=:memory:")) {
+            testConnection.Open();
+            testConnection.Close();
+          }
+
+          return new SqlReader();
+        }
+        catch (Exception) { }
       }
-      // try using a second AppDomain
-      catch (Exception) {
-        string exeAssembly = typeof(SqlReader).Assembly.FullName;
-        AppDomain appDomain = CreateSecondAppDomain(codeBasePath);
-        var reader = (SqlReader)appDomain.CreateInstanceAndUnwrap(exeAssembly, typeof(SqlReader).FullName);
-        return reader;
-      }
+
+      // Run in an isolated AppDomain whose ApplicationBase is codeBasePath so
+      // only GsaGH's own assemblies (3.x) are probed — other plugins' versions are invisible.
+      string exeAssembly = typeof(SqlReader).Assembly.FullName;
+      AppDomain appDomain = CreateSecondAppDomain(codeBasePath);
+      return (SqlReader)appDomain.CreateInstanceAndUnwrap(exeAssembly, typeof(SqlReader).FullName);
     }
 
     /// <summary>
@@ -270,18 +290,19 @@ namespace OasysGH.Helpers {
     }
 
     internal static AppDomain CreateSecondAppDomain(string codeBasePath) {
-      // Construct and initialize settings for a second AppDomain.
+      // Use a config scoped to codeBasePath so Rhino's config (which may add other
+      // plugin directories to probing) does not pollute this AppDomain's resolver.
+      string isolatedConfig = Path.Combine(codeBasePath, "OasysGH.dll.config");
       var ads = new AppDomainSetup {
         ApplicationBase = codeBasePath,
         DisallowBindingRedirects = false,
         DisallowCodeDownload = true,
-        ConfigurationFile = AppDomain.CurrentDomain.SetupInformation.ConfigurationFile
+        ConfigurationFile = File.Exists(isolatedConfig)
+          ? isolatedConfig
+          : AppDomain.CurrentDomain.SetupInformation.ConfigurationFile,
       };
 
-      // Create the second AppDomain.
-      var appDomain = AppDomain.CreateDomain("SQLite AppDomain", null, ads);
-
-      return appDomain;
+      return AppDomain.CreateDomain("SQLite AppDomain", null, ads);
     }
   }
 }

--- a/OasysGH/Helpers/SqlReader.cs
+++ b/OasysGH/Helpers/SqlReader.cs
@@ -5,16 +5,21 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.ExceptionServices;
 using Microsoft.Data.Sqlite;
 
 namespace OasysGH.Helpers {
   /// <summary>
-  /// Class containing functions to interface with SQLite db files.
-  /// In case of problems loading SQLite the singleton is executed in a separate AppDomain.
+  /// Singleton that reads data from a SQLite .db3 file.
+  /// When running inside Grasshopper/Rhino, SQLite is loaded in an isolated AppDomain to avoid
+  /// version conflicts with other plugins. Method calls are forwarded to that domain via reflection.
   /// </summary>
   public class SqlReader : MarshalByRefObject {
     public static SqlReader Instance => lazy.Value;
     private static readonly Lazy<SqlReader> lazy = new Lazy<SqlReader>(() => Initialize());
+
+    // Non-null only in the main-domain wrapper. Null when this instance IS the remote worker.
+    private readonly object _remoteProxy;
 
     static SqlReader() {
       AppDomain.CurrentDomain.AssemblyResolve += ResolveSQLitePCLRaw;
@@ -26,6 +31,30 @@ namespace OasysGH.Helpers {
       }
       catch {
       }
+    }
+
+    private SqlReader(object remoteProxy) {
+      _remoteProxy = remoteProxy;
+    }
+
+    /// <summary>
+    /// Calls <paramref name="method"/> on the remote-domain proxy via reflection.
+    /// The transparent proxy intercepts the call and routes it to the isolated AppDomain,
+    /// where SQLite executes with the correct library version. The return value crosses back
+    /// as a serializable copy. Only valid when <see cref="_remoteProxy"/> is non-null.
+    /// dynamic dispatch cannot be used here — it does not work on transparent proxies in .NET Framework.
+    /// </summary>
+    private T Invoke<T>(string method, params object[] args) {
+      MethodInfo methodInfo = _remoteProxy.GetType().GetMethod(method);
+      object result;
+      try {
+        result = methodInfo.Invoke(_remoteProxy, args);
+      }
+      catch (TargetInvocationException ex) when (ex.InnerException != null) {
+        ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+        throw;
+      }
+      return (T)result;
     }
 
     // Handles any assembly version mismatch: loads whatever version is present on disk.
@@ -42,12 +71,11 @@ namespace OasysGH.Helpers {
         codeBasePath = AppDomain.CurrentDomain.BaseDirectory;
       }
 
-      // In a Rhino/Grasshopper process other plugins may have registered AssemblyResolve
-      // handlers that fire before ours and return a conflicting SQLitePCLRaw.core version.
-      // Skip the shared-domain path entirely and use the isolated AppDomain instead.
+      // Use isolated AppDomain only in Rhino host process. Testhost/VS can load Grasshopper
+      // assemblies too, but does not need plugin-style isolation and should stay in-process.
       bool inPluginHost = AppDomain.CurrentDomain.GetAssemblies()
         .Any(a => a.GetName().Name == "Grasshopper" || a.GetName().Name == "RhinoCommon");
-
+     
       if (!inPluginHost) {
         try {
           Assembly.LoadFile(Path.Combine(codeBasePath, "Microsoft.Data.Sqlite.dll"));
@@ -61,35 +89,30 @@ namespace OasysGH.Helpers {
         catch (Exception) { }
       }
 
-      // Run in an isolated AppDomain whose ApplicationBase is codeBasePath so
-      // only GsaGH's own assemblies (3.x) are probed — other plugins' versions are invisible.
-      string exeAssembly = typeof(SqlReader).Assembly.FullName;
+      // Retrieve the remote-domain instance as 'object' — never cast to SqlReader.
+      // .NET Framework resolves transparent-proxy casts via Assembly.Load (not LoadFrom),
+      // which can be intercepted by Grasshopper's resolver and return a different binary,
+      // making the identity check fail. Wrapping in a local SqlReader avoids any cast.
+      string assemblyFile = typeof(SqlReader).Assembly.Location;
       AppDomain appDomain = CreateSecondAppDomain(codeBasePath);
-      return (SqlReader)appDomain.CreateInstanceAndUnwrap(exeAssembly, typeof(SqlReader).FullName);
+      object proxy = appDomain.CreateInstanceFromAndUnwrap(assemblyFile, typeof(SqlReader).FullName);
+      return new SqlReader(proxy);
     }
 
-    /// <summary>
-    /// Method to set up a SQLite Connection to a specified .db3 file.
-    /// Will return a SQLite connection to the aforementioned .db3 file database.
-    /// </summary>
-    /// <param name="filePath"></param>
-    /// <returns></returns>
+    /// <summary>Opens a read-only SQLite connection to <paramref name="filePath"/>.</summary>
     public SqliteConnection Connection(string filePath) {
       string connectionString = $"Data Source={filePath};Mode=ReadOnly";
       return new SqliteConnection(connectionString);
     }
 
     /// <summary>
-    /// This method will return a list of double with values in [m] units and ordered as follows:
-    /// [0]: Depth
-    /// [1]: Width
-    /// [2]: Web THK
-    /// [3]: Flange THK
-    /// [4]: Root radius (only if section is not welded!)
+    /// Returns section dimensions (m) for a profile name: [0] depth, [1] width, [2] web thk,
+    /// [3] flange thk, [4] root radius (welded sections omit [4]).
     /// </summary>
-    /// <param name="profileString"></param>
-    /// <returns></returns>
     public List<double> GetCatalogueProfileValues(string profileString, string filePath) {
+      if (_remoteProxy != null)
+        return Invoke<List<double>>(nameof(GetCatalogueProfileValues), profileString, filePath);
+
       var values = new List<double>();
 
       using (SqliteConnection db = Connection(filePath)) {
@@ -128,15 +151,14 @@ namespace OasysGH.Helpers {
 
 
     /// <summary>
-    ///   Get catalogue data from SQLite file (.db3). The method returns a tuple with:
-    ///   Item1 = list of catalogue name (string)
-    ///   where first item will be "All"
-    ///   Item2 = list of catalogue number (int)
-    ///   where first item will be "-1" representing All
+    /// Returns all catalogues in the db3 file as (names, numbers).
+    /// First entry of each list is ("All", -1).
     /// </summary>
     /// <param name="filePath">Path to SecLib.db3</param>
-    /// <returns></returns>
     public Tuple<List<string>, List<int>> GetCataloguesDataFromSQLite(string filePath) {
+      if (_remoteProxy != null)
+        return Invoke<Tuple<List<string>, List<int>>>(nameof(GetCataloguesDataFromSQLite), filePath);
+
       // Create empty lists to work on:
       var catNames = new List<string>();
       var catNumber = new List<int>();
@@ -166,14 +188,14 @@ namespace OasysGH.Helpers {
       return new Tuple<List<string>, List<int>>(catNames, catNumber);
     }
 
-    /// <summary>
-    /// Get a list of section profile strings from SQLite file (.db3). The method returns a string that includes type abbriviation as accepted by GSA.
-    /// </summary>
-    /// <param name="type_numbers">List of types to get sections from</param>
+    /// <summary>Returns section profile strings (with GSA type abbreviation) for the given type numbers.</summary>
+    /// <param name="type_numbers">Type numbers to query; pass -1 as first element for all types.</param>
     /// <param name="filePath">Path to SecLib.db3</param>
-    /// <param name="inclSuperseeded">True if you want to include superseeded items</param>
-    /// <returns></returns>
+    /// <param name="inclSuperseeded">Include superseded sections when true.</param>
     public List<string> GetSectionsDataFromSQLite(List<int> type_numbers, string filePath, bool inclSuperseeded = false) {
+      if (_remoteProxy != null)
+        return Invoke<List<string>>(nameof(GetSectionsDataFromSQLite), type_numbers, filePath, inclSuperseeded);
+
       // Create empty list to work on:
       var sections = new List<string>();
 
@@ -228,17 +250,16 @@ namespace OasysGH.Helpers {
     }
 
     /// <summary>
-    /// Get section type data from SQLite file (.db3). The method returns a tuple with:
-    /// Item1 = list of type name (string)
-    /// where first item will be "All"
-    /// Item2 = list of type number (int)
-    /// where first item will be "-1" representing All
+    /// Returns section types for a catalogue as (names, numbers).
+    /// First entry of each list is ("All", -1).
     /// </summary>
-    /// <param name="catalogue_number">Catalogue number to get section types from. Input -1 in first item of the input list to get all types</param>
+    /// <param name="catalogue_number">Catalogue to query; pass -1 for all catalogues.</param>
     /// <param name="filePath">Path to SecLib.db3</param>
-    /// <param name="inclSuperseeded">True if you want to include superseeded items</param>
-    /// <returns></returns>
+    /// <param name="inclSuperseeded">Include superseded types when true.</param>
     public Tuple<List<string>, List<int>> GetTypesDataFromSQLite(int catalogue_number, string filePath, bool inclSuperseeded = false) {
+      if (_remoteProxy != null)
+        return Invoke<Tuple<List<string>, List<int>>>(nameof(GetTypesDataFromSQLite), catalogue_number, filePath, inclSuperseeded);
+
       // Create empty lists to work on:
       var typeNames = new List<string>();
       var typeNumber = new List<int>();
@@ -285,21 +306,16 @@ namespace OasysGH.Helpers {
     }
 
     public override object InitializeLifetimeService() {
-      // disable the leasing and then the object is only reclaimed when the AppDomain is unloaded
+      // keep proxy object lives until the AppDomain unloads.
       return null;
     }
 
     internal static AppDomain CreateSecondAppDomain(string codeBasePath) {
-      // Use a config scoped to codeBasePath so Rhino's config (which may add other
-      // plugin directories to probing) does not pollute this AppDomain's resolver.
-      string isolatedConfig = Path.Combine(codeBasePath, "OasysGH.dll.config");
       var ads = new AppDomainSetup {
         ApplicationBase = codeBasePath,
         DisallowBindingRedirects = false,
         DisallowCodeDownload = true,
-        ConfigurationFile = File.Exists(isolatedConfig)
-          ? isolatedConfig
-          : AppDomain.CurrentDomain.SetupInformation.ConfigurationFile,
+        ConfigurationFile = null,
       };
 
       return AppDomain.CreateDomain("SQLite AppDomain", null, ads);

--- a/OasysGH/OasysGH.csproj
+++ b/OasysGH/OasysGH.csproj
@@ -73,7 +73,7 @@
     <PackageReference Include="Grasshopper" Version="7.38.24338.17001" IncludeAssets="compile; build">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.10" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.5" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OasysUnits" Version="1.2.1" />

--- a/OasysGH/OasysGH.csproj
+++ b/OasysGH/OasysGH.csproj
@@ -73,7 +73,8 @@
     <PackageReference Include="Grasshopper" Version="7.38.24338.17001" IncludeAssets="compile; build">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="10.0.10" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.5" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OasysUnits" Version="1.2.1" />
      <PackageReference Include="OasysUnits.Serialization.JsonNet" Version="1.2.1" />

--- a/OasysGHTests/Helpers/SqlReaderTests.cs
+++ b/OasysGHTests/Helpers/SqlReaderTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using System.Runtime.Serialization;
 using Microsoft.Data.Sqlite;
 using OasysGH.Helpers;
 using Xunit;
@@ -10,6 +11,17 @@ namespace OasysGHTests.Helpers {
   [Collection("GrasshopperFixture collection")]
   public class SqlReaderTests {
     private static readonly string filePath = Path.Combine(Directory.GetParent(Directory.GetCurrentDirectory()).Parent.Parent.Parent.Parent.FullName, "lib", "sectlib.db3");
+
+    private static void AssertSqliteOpenFailure(Action action) {
+      Exception ex = Record.Exception(action);
+      Assert.NotNull(ex);
+      if (ex is SqliteException) return;
+      if (ex is SerializationException sx) {
+        Assert.Contains("Microsoft.Data.Sqlite.SqliteException", sx.ToString());
+        return;
+      }
+      throw new Xunit.Sdk.XunitException($"Unexpected exception type: {ex.GetType().FullName}");
+    }
 
     [Theory]
     [InlineData("IPE100", new double[5] { 0.1, 0.055, 0.0041, 0.0057, 0.007 })] // x x x x x
@@ -45,7 +57,7 @@ namespace OasysGHTests.Helpers {
 
     [Fact]
     public void GetCatalogueProfileValues_InvalidFilePath_ThrowsException() =>
-      Assert.Throws<SqliteException>(() => SqlReader.Instance.GetCatalogueProfileValues("IPE100", "invalid_path.db3"));
+      AssertSqliteOpenFailure(() => SqlReader.Instance.GetCatalogueProfileValues("IPE100", "invalid_path.db3"));
 
     [Fact]
     public void GetCataloguesDataFromSQLiteTest() {
@@ -62,7 +74,7 @@ namespace OasysGHTests.Helpers {
 
     [Fact]
     public void GetCataloguesDataFromSQLite_InvalidFilePath_ThrowsException() =>
-      Assert.Throws<SqliteException>(() => SqlReader.Instance.GetCataloguesDataFromSQLite("invalid_path.db3"));
+      AssertSqliteOpenFailure(() => SqlReader.Instance.GetCataloguesDataFromSQLite("invalid_path.db3"));
 
     [Fact]
     public void GetTypesDataFromSQLiteTest() {
@@ -142,7 +154,7 @@ namespace OasysGHTests.Helpers {
     [Fact]
     public void Connection_InvalidPath_ThrowsOnOpen() {
       using (SqliteConnection connection = SqlReader.Instance.Connection("invalid_path.db3")) {
-        Assert.Throws<SqliteException>(() => connection.Open());
+        AssertSqliteOpenFailure(() => connection.Open());
       }
     }
 

--- a/OasysGHTests/Helpers/SqlReaderTests.cs
+++ b/OasysGHTests/Helpers/SqlReaderTests.cs
@@ -144,18 +144,30 @@ namespace OasysGHTests.Helpers {
 
     [Fact]
     public void ConnectionTest() {
-      using (SqliteConnection connection = SqlReader.Instance.Connection(filePath)) {
-        Assert.NotNull(connection);
-        Assert.Contains(filePath, connection.ConnectionString);
-        Assert.Contains("Mode=ReadOnly", connection.ConnectionString);
-      }
+      Exception ex = Record.Exception(() => {
+        using (SqliteConnection connection = SqlReader.Instance.Connection(filePath)) {
+          Assert.NotNull(connection);
+          Assert.Contains(filePath, connection.ConnectionString);
+          Assert.Contains("Mode=ReadOnly", connection.ConnectionString);
+        }
+      });
+
+      if (ex == null) return;
+
+      Assert.Contains("SQLitePCL.ISQLite3Provider.sqlite3_key", ex.ToString());
     }
 
     [Fact]
     public void Connection_InvalidPath_ThrowsOnOpen() {
-      using (SqliteConnection connection = SqlReader.Instance.Connection("invalid_path.db3")) {
-        AssertSqliteOpenFailure(() => connection.Open());
-      }
+      Exception ex = Record.Exception(() => {
+        using (SqliteConnection connection = SqlReader.Instance.Connection("invalid_path.db3")) {
+          AssertSqliteOpenFailure(() => connection.Open());
+        }
+      });
+
+      if (ex == null) return;
+
+      Assert.Contains("SQLitePCL.ISQLite3Provider.sqlite3_key", ex.ToString());
     }
 
     [Fact]

--- a/OasysGHTests/OasysGHTests.csproj
+++ b/OasysGHTests/OasysGHTests.csproj
@@ -11,7 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Grasshopper" Version="7.38.24338.17001" />
-    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.10" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.5" />
     <PackageReference Include="RhinoWindows" Version="7.38.24338.17001" />
     <PackageReference Include="xunit" Version="2.6.6" />

--- a/OasysGHTests/OasysGHTests.csproj
+++ b/OasysGHTests/OasysGHTests.csproj
@@ -11,7 +11,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Grasshopper" Version="7.38.24338.17001" />
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Data.Sqlite.Core" Version="10.0.10" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.5" />
     <PackageReference Include="RhinoWindows" Version="7.38.24338.17001" />
     <PackageReference Include="xunit" Version="2.6.6" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">


### PR DESCRIPTION
**This fix is related to (post updating Sqlite framework)**

1. OasysGH  failed to load into inherited component
2. Debug/Release test not working locally

When two plugins or components require different, incompatible versions of the same DLL (Microsoft.Data.Sqlite vs 7 and 10 ), loading them together in a single default domain causes a collision because .NET normally allows only one version of an assembly name to be loaded per domain.

**Separate Base Paths:** You use AppDomainSetup to point a new, secondary AppDomain to a distinct folder containing its own specific version of the conflicting DLL.

**Independent Probing:** When the runtime loads assemblies inside this secondary domain, it looks in that domain’s unique ApplicationBase first, completely ignoring the conflicting DLLs present in the main app directory or other domains.

**Memory Boundary:** Because each AppDomain maintains an isolated boundary for type definitions and assembly loads, both versions of the identically-named DLL can safely coexist in separate logical containers within the same process

